### PR TITLE
Improve uncompressed file handling and update concordance docs

### DIFF
--- a/analyses/Concordance.md
+++ b/analyses/Concordance.md
@@ -13,11 +13,11 @@ building:
 usage:
 ```
 concordance \
---father NA12877 \ 
+--father NA12877 \
 --mother NA12878 \
 --vcf {}.vcf.gz \
---inheritance data/ceph.GRCh38.viterbi.csv \ 
+--inheritance data/ceph.GRCh38.viterbi.csv.gz \
 --prefix {} > std.out
 ```
 
-The input inheritance vectors are distributed with this repo and can be found in "data/ceph.GRCh38.viterbi.csv.gz". Unzip the csv file before running the concordance code.
+The input inheritance vectors are distributed with this repo and can be found in "data/ceph.GRCh38.viterbi.csv.gz".

--- a/code/rust/src/bin/concordance.rs
+++ b/code/rust/src/bin/concordance.rs
@@ -93,12 +93,16 @@ impl std::fmt::Display for InheritanceBlock {
 
 fn parse_inht(inht_fn: String) -> Vec<InheritanceBlock> {
     use std::fs::File;
+    use std::io::Seek;
 
     let mut inht_fp = File::open(&inht_fn).expect("Error reading inheritance CSV file.");
     let inht_fp_gz = flate2::read::GzDecoder::new(&mut inht_fp);
     let inht_fp: Box<dyn std::io::Read> = match inht_fp_gz.header() {
         Some(_) => Box::new(inht_fp_gz),
-        None => Box::new(File::open(&inht_fn).expect("Error reading inheritance CSV file.")),
+        None => {
+            inht_fp.rewind().unwrap();
+            Box::new(inht_fp)
+        }
     };
     let mut reader = ReaderBuilder::new().from_reader(inht_fp);
 


### PR DESCRIPTION
This cleans up the second file open, and updates the corresponding instructions in the concordance doc.